### PR TITLE
Rename all tsconfig to standard name

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,10 @@
       ]
     }
   },
+  "include": [
+    "apps/**/*",
+    "libs/**/*"
+  ],
   "exclude": [
     "node_modules",
     "dist"


### PR DESCRIPTION
Is there a reason for calling them "tsconfig.app.json" and "tsonfig.lib.json" ?

If not, let's move to standard, as it can mess up with IDE's and the build system