### PR TITLE
Fix: lib/repository

### DIFF
--- a/libs/repository/src/dtos/base-search.dto.ts
+++ b/libs/repository/src/dtos/base-search.dto.ts
@@ -1,4 +1,4 @@
-import { ApiModelProperty } from '@nestjs/swagger';
+import { ApiModelProperty } from '@nestjs/swagger/dist/decorators/api-model-property.decorator';
 // import { Transform } from 'class-transformer';
 // import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
 

--- a/libs/repository/src/dtos/page-meta.dto.ts
+++ b/libs/repository/src/dtos/page-meta.dto.ts
@@ -1,4 +1,4 @@
-import { ApiModelProperty } from '@nestjs/swagger';
+import { ApiModelProperty } from '@nestjs/swagger/dist/decorators/api-model-property.decorator';
 import { PageOptionsDto } from './page-options.dto';
 
 interface IPageMetaDtoParameters {

--- a/libs/repository/src/dtos/page-options.dto.ts
+++ b/libs/repository/src/dtos/page-options.dto.ts
@@ -1,4 +1,4 @@
-import { ApiModelPropertyOptional } from '@nestjs/swagger';
+import { ApiModelPropertyOptional } from '@nestjs/swagger/dist/decorators/api-model-property.decorator';
 // import { Type } from 'class-transformer';
 // import { IsEnum, IsInt, Min, IsOptional, Max, IsString, IsNotEmpty } from 'class-validator';
 

--- a/libs/repository/src/dtos/page-options.dto.ts
+++ b/libs/repository/src/dtos/page-options.dto.ts
@@ -6,7 +6,7 @@ import { Order } from '../enums';
 
 export class PageOptionsDto {
   @ApiModelPropertyOptional({
-    enum: Order,
+    enum: Object.values(Order),
     default: Order.ASC,
   })
   // @IsEnum(Order)

--- a/libs/repository/src/enums/index.ts
+++ b/libs/repository/src/enums/index.ts
@@ -1,1 +1,1 @@
-export * from './order.edum';
+export * from './order.enum';

--- a/libs/repository/src/enums/order.edum.ts
+++ b/libs/repository/src/enums/order.edum.ts
@@ -1,4 +1,0 @@
-export enum Order {
-  ASC = 'ASC',
-  DESC = 'DESC',
-}

--- a/libs/repository/src/enums/order.enum.ts
+++ b/libs/repository/src/enums/order.enum.ts
@@ -1,0 +1,4 @@
+export enum Order {
+  ASC = 0,
+  DESC = 1,
+}


### PR DESCRIPTION
* Fix: Explicit dependency to fix missing export
* Fix: Typo in file name
* Fix: Convert Order enum to array when passing to `ApiModelPropertyOptional` decorator

ToDo: notify @nestjs/swagger so they export things correctly (or is `api-model-property.decorator` so uber-experimental that they need to hide it ?)