### PR TITLE
Fix service-notification build

### DIFF
--- a/apps/service-notification/src/configs/sendgrid-config.service.ts
+++ b/apps/service-notification/src/configs/sendgrid-config.service.ts
@@ -24,6 +24,7 @@ export class SendgridConfigService implements SendGridModuleOptionsFactory {
             enable: true,
           },
         },
+        text: "N/A",
       },
     };
   }


### PR DESCRIPTION
When building service-notification, you get the following error output:
```
ERROR in /nest/apps/service-notification/src/configs/sendgrid-config.service.ts
./apps/service-notification/src/configs/sendgrid-config.service.ts
[tsl] ERROR in /nest/apps/service-notification/src/configs/sendgrid-config.service.ts(16,7)
      TS2322: Type '{ from: string; trackingSettings: { clickTracking: { enable: true; enableText: true; }; openTracking: { enable: true; }; }; }' is not assignable to type 'MailDataRequired'.
  Type '{ from: string; trackingSettings: { clickTracking: { enable: true; enableText: true; }; openTracking: { enable: true; }; }; }' is not assignable to type 'MailData & { content: MailContent[] & { 0: MailContent; }; }'.
    Property 'content' is missing in type '{ from: string; trackingSettings: { clickTracking: { enable: true; enableText: true; }; openTracking: { enable: true; }; }; }' but required in type '{ content: MailContent[] & { 0: MailContent; }; }'.
```
Basically, a required key "content" or "text" (others are available) is needed to match expected returned type.