### PR TITLE
Fixed script running on systems where sh points to dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ You should start the microservices in any other. Example
   
 # Generate protobuf typescript definitions and please fix the path for timestamps import (You should do this only when you update the protobuf files)
 # and also build the proto-scheme lib (You should do this only when you update the protobuf files)
-# in `lib/proto-schem`  
+# in `lib/proto-schem`
+# Also adds configuration(config.example files) to consul K/V registry (consul need to be running)
+# You need jq and yq programs to use it   
 $ yarn setup:local
   
 # Start the account service  

--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 # shellcheck disable=SC2207
-PROJECTS=( $(jq -r '.projects[] | select(.type == "application") | .root' ./nest-cli.json) )
+PROJECTS=$(jq -r '.projects[] | select(.type == "application") | .root' ./nest-cli.json)
 BOOTSTRAP_PATH=src/bootstrap-development.yaml
 CONFIG_PATH=config.example
 
 echo "Service Registration system started"
 
-for PROJECT_DIR in "${PROJECTS[@]}" ; do
+for PROJECT_DIR in ${PROJECTS} ; do
   if [ ! -f "./${PROJECT_DIR}/${BOOTSTRAP_PATH}" ]; then
     echo "./${PROJECT_DIR}/${BOOTSTRAP_PATH} not found, skipping service"
     continue
   fi
 
-  SVC_NAME=$(yq r ./${PROJECT_DIR}/${BOOTSTRAP_PATH} 'service.name' )
+  SVC_NAME=$(yq r ./"${PROJECT_DIR}"/${BOOTSTRAP_PATH} 'service.name' )
   echo "Registering ${SVC_NAME}"
 
   if [ ! -f "./${PROJECT_DIR}/${CONFIG_PATH}" ]; then
@@ -22,7 +22,7 @@ for PROJECT_DIR in "${PROJECTS[@]}" ; do
 
     echo "**** ${PROJECT_DIR}"
 
-  consul kv put ultimatebackend/config/${SVC_NAME} \@./${PROJECT_DIR}/${CONFIG_PATH}
+  consul kv put ultimatebackend/config/"${SVC_NAME}" \@./"${PROJECT_DIR}"/${CONFIG_PATH}
 done
 
 echo "Service Registration system completed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # shellcheck disable=SC2207
-PROJECTS=( $(jq -r '.projects[].root' ./nest-cli.json) )
+PROJECTS=$(jq -r '.projects[].root' ./nest-cli.json)
 
 echo "Service and Library build system started"
 
-for VAR in "${PROJECTS[@]}" ; do
-  echo "Building for" "${VAR:5}"
-  npx nest build "${VAR:5}"
+for VAR in ${PROJECTS} ; do
+  echo "Building for" "${VAR}"
+  npx nest build "${VAR}"
 done
 
 echo "Service and Library build system completed"


### PR DESCRIPTION
Changes to the script make it compatible with dash or bash.

Not all systems use bash, and the script fails when using dash.

The shebang is ignored because we don't run the file directly(but through yarn)

Changed looping over an array in the scripts