### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ mongod
 If you have docker installed  
 ```bash  
 docker run -d -p 27017:27017 mongo  
-docker run -d -p 1113:1113 -p 2113:2113 eventstore/eventstore  
+docker run -d -p 1113:1113 -p 2113:2113 eventstore/eventstore --insecure # insecure flag specifies no certificate required - suitable for devmode 
 docker run -d -p 6379:6379 redis  
 ```  
   


### PR DESCRIPTION
Updated README section on how to run eventstore using docker.

Without --insecure flag, the container fails silently, without binding ports.

This is needed, as deploying with Docker Compose still has issues, and people trying to deploy without can potentially waste hours like I did.

To actually find the issue you need to run the container in interactive mode and find out that:
```
[    1, 1,15:38:01.906,INF] TLS is enabled on at least one TCP/HTTP interface - a certificate is required to run EventStoreDB.
[    1, 1,15:38:01.907,ERR] Invalid Configuration Encountered
[    1, 1,15:38:01.907,ERR] A certificate is required unless insecure mode (--insecure) is set.
```