### PR TITLE
mongodb $set operator added to repo-orm

### DIFF
--- a/libs/repo-orm/src/database/mongo/repository/base-mongo.repository.ts
+++ b/libs/repo-orm/src/database/mongo/repository/base-mongo.repository.ts
@@ -542,7 +542,7 @@ export class BaseMongoRepository<DOC, DTO = DOC> {
     const updates = await this.invokeEvents(
       PRE_KEY,
       ['UPDATE', 'UPDATE_ONE'],
-      req.updates,
+      { $set: { ...req.updates } },
     );
 
     const conditions = cleanEmptyProperties({
@@ -568,7 +568,7 @@ export class BaseMongoRepository<DOC, DTO = DOC> {
     const updates = await this.invokeEvents(
       PRE_KEY,
       ['UPDATE', 'UPDATE_ONE'],
-      req.updates,
+      { $set: { ...req.updates } },
     );
 
     const conditions = cleanEmptyProperties({
@@ -603,7 +603,7 @@ export class BaseMongoRepository<DOC, DTO = DOC> {
     const updates = await this.invokeEvents(
       PRE_KEY,
       ['UPDATE', 'UPDATE_ONE'],
-      req.updates,
+      { $set: { ...req.updates } },
     );
 
     const conditions = cleanEmptyProperties({


### PR DESCRIPTION
when using any of the mongodb update functions in the repo-orm to update a document, this exception is thrown.
`Error: the updateOne operation document must contain atomic operators`, so I added the $set operator to the functions appropriately.