### PR TITLE
Fix: Error: unknown command "r" for "yq" while running yarn setup:local

### DIFF
--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -12,7 +12,7 @@ for PROJECT_DIR in ${PROJECTS} ; do
     continue
   fi
 
-  SVC_NAME=$(yq r ./"${PROJECT_DIR}"/${BOOTSTRAP_PATH} 'service.name' )
+  SVC_NAME=$(yq e '.service.name' ./"${PROJECT_DIR}"/${BOOTSTRAP_PATH} )
   echo "Registering ${SVC_NAME}"
 
   if [ ! -f "./${PROJECT_DIR}/${CONFIG_PATH}" ]; then


### PR DESCRIPTION
While running `yarn setup:local` I get `Error: unknown command "r" for "yq"`

I installed yq on Ubuntu using
`sudo snap install yq`
In version:
```
yq --version
yq (https://github.com/mikefarah/yq/) version 4.16.2
```

Following the docs http://mikefarah.github.io/yq/, the `r` command doesn't seem to exist anymore whatever the OS is.

Btw, the README Configuration section says:

> Before starting the services, please create the appropriate consul (Default service registry Consul) kv store config for all the services. You can find the example config
in the folders of each service called config.example. The consul config key of say the account service should be
ultimatebackend/config/io.ultimatebackend.srv.account and just paste the config.yaml content in the consul store for that key in yaml and save.

This seems out of date as the `yarn setup:local` script does the job and also misleading as the content to store as kv in Consul is taken from `bootstrap-development.yaml`
- Am I misunderstanding the config and should let it this way?
- Should I remove this part of the README? Or replace it by something else?
- Should I also remove config.example files?
- Should I create a Github Action to run the setup steps and test my change? (I see a CircleCI config but I don't know where it's run, no URL or badge, and if I don't know if `yarn run test` runs the local setup)

Anyway, thanks lot for for your work! 